### PR TITLE
Fixes for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ go:
   - tip
 
 before_install:
-- sudo apt-get install libpcap-dev -y
-- go get golang.org/x/tools/cmd/cover
-- go get github.com/mattn/goveralls
+  - sudo apt-get install libpcap-dev -y
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
 
 script:  
-- test -z "$(gofmt -s -l . | tee /dev/stderr)"
-- go test -v -covermode=count -coverprofile=coverage.out
+  - test -z "$(gofmt -s -l . | tee /dev/stderr)"
+  - go test -v ./...

--- a/http/ping/ping_test.go
+++ b/http/ping/ping_test.go
@@ -3,16 +3,18 @@ package ping_test
 import (
 	"testing"
 
+	"github.com/mehrdadrad/mylg/cli"
 	"github.com/mehrdadrad/mylg/http/ping"
 	"gopkg.in/h2non/gock.v0"
 )
 
 func TestNewPing(t *testing.T) {
-	url, _ := ping.NewPing("help")
+	cfg, _ := cli.ReadDefaultConfig()
+	url, _ := ping.NewPing("help", cfg)
 	if url != nil {
 		t.Error("NewPing expected nil but returned string")
 	}
-	_, err := ping.NewPing(".")
+	_, err := ping.NewPing(".", cfg)
 	if err == nil {
 		t.Error("Newping expected error but it didn't return")
 	}
@@ -23,7 +25,8 @@ func TestPing(t *testing.T) {
 	gock.New(url).
 		Reply(200)
 
-	p, _ := ping.NewPing(url)
+	cfg, _ := cli.ReadDefaultConfig()
+	p, _ := ping.NewPing(url, cfg)
 	r, _ := p.Ping()
 	if r.StatusCode != 200 {
 		t.Error("PingGet expected to get 200 but didn't")

--- a/icmp/icmp_test.go
+++ b/icmp/icmp_test.go
@@ -1,13 +1,15 @@
 package icmp_test
 
 import (
+	"github.com/mehrdadrad/mylg/cli"
 	"github.com/mehrdadrad/mylg/icmp"
 	"net"
 	"testing"
 )
 
 func TestSetIP(t *testing.T) {
-	_, err := icmp.NewPing("8.8.8.8")
+	cfg, _ := cli.ReadDefaultConfig()
+	_, err := icmp.NewPing("8.8.8.8", cfg)
 	if err != nil {
 		t.Error("NewPing failed with error:", err)
 	}


### PR DESCRIPTION
This PR fixes some broken tests, some intendation in .travis.yaml and makes travis run tests on all packages and not just main. Removed cover from tests since it [doesn't support](https://github.com/golang/go/issues/6909) multiple packages out of the box but it seems better to run tests on all packages than getting a empty coverage report that isn't used anyways(?)

There are some [potential](https://github.com/h12w/gosweep) [fixes](https://github.com/modocache/gover) for generating reports from all packages but not sure if you want to implement them.

PS. Didn't check for err from cli.ReadDefaultConfig() since its already tested in cli/config_test