### PR TITLE
Adds a note in README about version 1.7 of golang is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ apt-get install libpcap-dev
 brew install homebrew/dupes/libpcap
 ```
 
-Given that the Go Language compiler is installed, you can build and run:
+Given that the Go Language compiler (version 1.7 or greater is required) is installed, you can build and run it with:
 
 ```
 git clone https://github.com/mehrdadrad/mylg.git


### PR DESCRIPTION
Hi Mehrdad!

Noticed you implemented httptrace in hping, cool! Was actually thinking about doing a PR with just that since I was playing around with httptrace the other day. Anywho, since it requires go 1.7 I thought it would be a good idea to have a note about that in the README since, for instance, Ubuntu LTS ships with go 1.6 and I also took the liberty to update the sentence a little bit