### PR TITLE
Httptrace layout

### DIFF
--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -283,6 +283,10 @@ func (p *Ping) Ping() (Result, error) {
 	}
 
 	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Don't follow redirects
+			return http.ErrUseLastResponse
+		},
 		Timeout:   p.timeout,
 		Transport: tr,
 	}

--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -48,7 +48,6 @@ type Ping struct {
 // Result holds Ping result
 type Result struct {
 	StatusCode int
-	ConnTime   float64
 	TotalTime  float64
 	Size       int
 	Proto      string

--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -54,6 +54,51 @@ type Result struct {
 	Proto      string
 	Server     string
 	Status     string
+	Trace      Trace
+}
+
+// Trace holds trace results
+type Trace struct {
+	ConnectionTime  float64
+	TimeToFirstByte float64
+}
+
+// PrintPingResult prints result from each individual ping
+func (r Result) PrintPingResult(p *Ping, seq int, err error) {
+	pStrPrefix := "HTTP Response seq=%d, "
+	pStrSuffix := "proto=%s, status=%d, size=%d Bytes, time=%.3f ms"
+	pStrSuffixHead := "proto=%s, status=%d, time=%.3f ms"
+	pStrTrace := ", connection=%.3f ms, first byte read=%.3f ms\n"
+
+	if p.quiet {
+		if err != nil {
+			fmt.Printf("!")
+			return
+		}
+		fmt.Printf(".")
+		return
+	}
+
+	if err != nil {
+		errmsg := strings.Split(err.Error(), ": ")
+		fmt.Printf(pStrPrefix+"%s\n", seq, errmsg[len(errmsg)-1])
+		return
+	}
+
+	if p.method == "HEAD" {
+		if p.tracerEnabled {
+			fmt.Printf(pStrPrefix+pStrSuffixHead+pStrTrace, seq, r.Proto, r.StatusCode, r.TotalTime*1e3, r.Trace.ConnectionTime, r.Trace.TimeToFirstByte)
+			return
+		}
+		fmt.Printf(pStrPrefix+pStrSuffixHead+"\n", seq, r.Proto, r.StatusCode, r.TotalTime*1e3)
+		return
+	}
+	if p.tracerEnabled {
+		fmt.Printf(pStrPrefix+pStrSuffix+pStrTrace, seq, r.Proto, r.StatusCode, r.Size, r.TotalTime*1e3, r.Trace.ConnectionTime, r.Trace.TimeToFirstByte)
+		return
+	}
+	fmt.Printf(pStrPrefix+pStrSuffix+"\n", seq, r.Proto, r.StatusCode, r.Size, r.TotalTime*1e3)
+	return
 }
 
 // NewPing validate and constructs request object
@@ -147,33 +192,17 @@ func (p *Ping) Run() {
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 
-	pStrPrefix := "HTTP Response seq=%d, "
-	pStrSuffix := "proto=%s, status=%d, size=%d Bytes, time=%.3f ms\n"
-	pStrSuffixHead := "proto=%s, status=%d, time=%.3f ms\n"
 	fmt.Printf("HPING %s (%s), Method: %s, DNSLookup: %.4f ms\n", p.host, p.rAddr, p.method, p.nsTime.Seconds()*1e3)
 
 LOOP:
 	for i := 0; i < p.count; i++ {
 		if r, err := p.Ping(); err == nil {
-			if !p.quiet {
-				if p.method != "HEAD" {
-					fmt.Printf(pStrPrefix+pStrSuffix, i, r.Proto, r.StatusCode, r.Size, r.TotalTime*1e3)
-				} else {
-					fmt.Printf(pStrPrefix+pStrSuffixHead, i, r.Proto, r.StatusCode, r.TotalTime*1e3)
-				}
-			} else {
-				fmt.Printf(".")
-			}
+			r.PrintPingResult(p, i, err)
 			c[r.StatusCode]++
 			s = append(s, r.TotalTime*1e3)
 		} else {
 			c[-1]++
-			if !p.quiet {
-				errmsg := strings.Split(err.Error(), ": ")
-				fmt.Printf(pStrPrefix+"%s\n", i, errmsg[len(errmsg)-1])
-			} else {
-				fmt.Printf("!")
-			}
+			r.PrintPingResult(p, i, err)
 		}
 		select {
 		case <-sigCh:
@@ -309,7 +338,7 @@ func (p *Ping) Ping() (Result, error) {
 	req.Header.Add("User-Agent", p.uAgent)
 	// context, tracert
 	if p.tracerEnabled && !p.quiet {
-		req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracer()))
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracer(&r)))
 	}
 	resp, err = client.Do(req)
 
@@ -335,7 +364,7 @@ func (p *Ping) Ping() (Result, error) {
 	return r, nil
 }
 
-func tracer() *httptrace.ClientTrace {
+func tracer(r *Result) *httptrace.ClientTrace {
 	var (
 		begin   = time.Now()
 		elapsed time.Duration
@@ -345,12 +374,12 @@ func tracer() *httptrace.ClientTrace {
 		ConnectDone: func(network, addr string, err error) {
 			elapsed = time.Since(begin)
 			begin = time.Now()
-			fmt.Printf("# connection completed to %s in %.3f ms\n", addr, elapsed.Seconds()*1e3)
+			r.Trace.ConnectionTime = elapsed.Seconds() * 1e3
 		},
 		GotFirstResponseByte: func() {
 			elapsed = time.Since(begin)
 			begin = time.Now()
-			fmt.Printf("# read first byte in %.3f ms\n", elapsed.Seconds()*1e3)
+			r.Trace.TimeToFirstByte = elapsed.Seconds() * 1e3
 		},
 	}
 }

--- a/http/ping/ping_test.go
+++ b/http/ping/ping_test.go
@@ -23,13 +23,13 @@ func TestNewPing(t *testing.T) {
 func TestPing(t *testing.T) {
 	var url = "google.com"
 	gock.New(url).
-		Reply(302)
+		Reply(301)
 
 	cfg, _ := cli.ReadDefaultConfig()
 	p, _ := ping.NewPing(url, cfg)
 	r, _ := p.Ping()
-	if r.StatusCode != 302 {
-		t.Error("PingGet expected to get 302 but didn't, I got:", r.StatusCode)
+	if r.StatusCode != 301 {
+		t.Error("PingGet expected to get 301 but didn't, I got:", r.StatusCode)
 	}
 	if r.TotalTime == 0 {
 		t.Error("PingGet expected to set totaltime but it didn't")

--- a/http/ping/ping_test.go
+++ b/http/ping/ping_test.go
@@ -28,8 +28,8 @@ func TestPing(t *testing.T) {
 	cfg, _ := cli.ReadDefaultConfig()
 	p, _ := ping.NewPing(url, cfg)
 	r, _ := p.Ping()
-	if r.StatusCode != 200 {
-		t.Error("PingGet expected to get 200 but didn't")
+	if r.StatusCode != 302 {
+		t.Error("PingGet expected to get 302 but didn't")
 	}
 	if r.TotalTime == 0 {
 		t.Error("PingGet expected to set totaltime but it didn't")

--- a/http/ping/ping_test.go
+++ b/http/ping/ping_test.go
@@ -23,13 +23,13 @@ func TestNewPing(t *testing.T) {
 func TestPing(t *testing.T) {
 	var url = "google.com"
 	gock.New(url).
-		Reply(200)
+		Reply(302)
 
 	cfg, _ := cli.ReadDefaultConfig()
 	p, _ := ping.NewPing(url, cfg)
 	r, _ := p.Ping()
 	if r.StatusCode != 302 {
-		t.Error("PingGet expected to get 302 but didn't")
+		t.Error("PingGet expected to get 302 but didn't, I got:", r.StatusCode)
 	}
 	if r.TotalTime == 0 {
 		t.Error("PingGet expected to set totaltime but it didn't")


### PR DESCRIPTION
Hello!

To me, it feels more natural and less cluttered to print the results from the httptrace on the same line as the rest of the result. Not sure if you agree, if you don't you can just close this PR. :)

This PR does four things:

- Changes the behaviour of hping so it does not follow redirects, for two reasons: 1) if I want to ping a webpage, I just want to know if it responds. A 301/302 is a proper response and if I want to know if the target of the redirect responds correctly I'll just ping that directly. And 2) because a redirect generates a trace for each redirect.
- Prints the result of the trace on the same line as the other ping results.
- Moved the print-logic of each result to a method to clean up the Ping.Run()-loop
- Removed a unused field in Result{}