### PR TITLE
Changes hping so it accepts host:port and fixes the test for hping so…

### DIFF
--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -114,15 +114,22 @@ func NewPing(args string, cfg cli.Config) (*Ping, error) {
 	if err != nil {
 		return &Ping{}, fmt.Errorf("cannot parse url")
 	}
-	sTime := time.Now()
-	ipAddr, err := net.ResolveIPAddr("ip", u.Host)
+
+	host, _, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		return &Ping{}, fmt.Errorf("cannot resolve %s: Unknown host", u.Host)
+		host = u.Host
+	}
+
+	sTime := time.Now()
+
+	ipAddr, err := net.ResolveIPAddr("ip", host)
+	if err != nil {
+		return &Ping{}, fmt.Errorf("cannot resolve %s: Unknown host", host)
 	}
 
 	p := &Ping{
 		url:           URL,
-		host:          u.Host,
+		host:          host,
 		rAddr:         ipAddr,
 		buf:           cli.SetFlag(flag, "d", "mylg").(string),
 		count:         cli.SetFlag(flag, "c", cfg.Hping.Count).(int),

--- a/http/ping/ping_test.go
+++ b/http/ping/ping_test.go
@@ -1,11 +1,13 @@
 package ping_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/mehrdadrad/mylg/cli"
 	"github.com/mehrdadrad/mylg/http/ping"
-	"gopkg.in/h2non/gock.v0"
 )
 
 func TestNewPing(t *testing.T) {
@@ -21,16 +23,22 @@ func TestNewPing(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
-	var url = "google.com"
-	gock.New(url).
-		Reply(301)
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "test")
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(testHandler))
+	defer ts.Close()
 
 	cfg, _ := cli.ReadDefaultConfig()
-	p, _ := ping.NewPing(url, cfg)
+	p, _ := ping.NewPing(ts.URL, cfg)
 	r, _ := p.Ping()
-	if r.StatusCode != 301 {
-		t.Error("PingGet expected to get 301 but didn't, I got:", r.StatusCode)
+
+	if r.StatusCode != 200 {
+		t.Error("PingGet expected to get 200 but didn't, I got:", r.StatusCode)
 	}
+
 	if r.TotalTime == 0 {
 		t.Error("PingGet expected to set totaltime but it didn't")
 	}


### PR DESCRIPTION
… it doesn't send outgoing requests. As discussed on gitter the test now uses the vanilla golang net/http/httptest instead of gock since gock doesn't seem to work with custom http.Client-Transports.