### PR TITLE
Use environment variables to set proxy instead of a option

### DIFF
--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -37,7 +37,6 @@ type Ping struct {
 	transport     *http.Transport
 	rAddr         net.Addr
 	nsTime        time.Duration
-	conn          net.Conn
 	quiet         bool
 	dCompress     bool
 	kAlive        bool


### PR DESCRIPTION
Hello!

This PR removes a unused field in the Ping-struct and also changes hping to use the widely used http(s)_proxy environment variabels instead of a option for a proxy which would make it easier to use if you're behind a proxy imho.