### PR TITLE
Fix for #44

### DIFF
--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -127,7 +127,7 @@ func NewPing(args string, cfg cli.Config) (*Ping, error) {
 
 	p := &Ping{
 		url:           URL,
-		host:          host,
+		host:          u.Host,
 		rAddr:         ipAddr,
 		buf:           cli.SetFlag(flag, "d", "mylg").(string),
 		count:         cli.SetFlag(flag, "c", cfg.Hping.Count).(int),


### PR DESCRIPTION
As promised, fixes #44 so hping displays host/port pair, i.e:

```
foo:mylg emil$ ./mylg hping domain.tld -c 1
HPING domain.tld (127.0.0.1), Method: HEAD, DNSLookup: 1.9236 ms
HTTP Response seq=0, proto=HTTP/1.1, status=301, time=82.465 ms

--- domain.tld HTTP ping statistics --- 
1 requests transmitted, 1 replies received, 0% requests failed
HTTP Round-trip min/avg/max = 82.46/82.46/82.46 ms
HTTP Code [301] responses : [████████████████████] 100.00% 

foo:mylg emil$ ./mylg hping domain.tld:8080 -c 1
HPING domain.tld:8080 (127.0.0.1), Method: HEAD, DNSLookup: 2.1546 ms
HTTP Response seq=0, connection refused

--- domain.tld:8080 HTTP ping statistics --- 
1 requests transmitted, 0 replies received, 100% requests failed
HTTP Round-trip min/avg/max = 0.00/0.00/0.00 ms
````