### PR TITLE
Adds a configurable setting for hping interval and cleans up help

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -18,6 +18,7 @@ var defaultConfig = `{
 	},
 	"hping" : {
 		"timeout"  : "2s",
+		"interval" : "0s",
 		"method"   : "HEAD",
 		"data"	   : "mylg",
 		"count"	   : 5
@@ -66,10 +67,11 @@ type Ping struct {
 
 // HPing represents ping command options
 type HPing struct {
-	Timeout string `json:"timeout" tag:"lower"`
-	Method  string `json:"method" tag:"upper"`
-	Data    string `json:"data"`
-	Count   int    `json:"count"`
+	Timeout  string `json:"timeout" tag:"lower"`
+	Interval string `json:"interval" tag:"interval"`
+	Method   string `json:"method" tag:"upper"`
+	Data     string `json:"data"`
+	Count    int    `json:"count"`
 }
 
 // Web represents web command options

--- a/cli/config.go
+++ b/cli/config.go
@@ -18,7 +18,7 @@ var defaultConfig = `{
 	},
 	"hping" : {
 		"timeout"  : "2s",
-		"interval" : "0s",
+		"interval" : "1s",
 		"method"   : "HEAD",
 		"data"	   : "mylg",
 		"count"	   : 5

--- a/cli/config.go
+++ b/cli/config.go
@@ -68,7 +68,7 @@ type Ping struct {
 // HPing represents ping command options
 type HPing struct {
 	Timeout  string `json:"timeout" tag:"lower"`
-	Interval string `json:"interval" tag:"interval"`
+	Interval string `json:"interval" tag:"lower"`
 	Method   string `json:"method" tag:"upper"`
 	Data     string `json:"data"`
 	Count    int    `json:"count"`

--- a/http/ping/ping.go
+++ b/http/ping/ping.go
@@ -142,7 +142,7 @@ func NewPing(args string, cfg cli.Config) (*Ping, error) {
 	}
 
 	// set interval
-	interval := cli.SetFlag(flag, "i", "0s").(string)
+	interval := cli.SetFlag(flag, "i", cfg.Hping.Interval).(string)
 	p.interval, err = time.ParseDuration(interval)
 	if err != nil {
 		return p, fmt.Errorf("Failed to parse interval: %s. Correct syntax is <number>s/ms", err)
@@ -430,8 +430,8 @@ func help(cfg cli.Config) {
 
     options:
           -c   count        Send 'count' requests (default: %d)
-          -t   timeout      Set a time limit for requests in ms/s (default is %s)
-          -i   interval     Set a wait time between sending each request in ms/s
+          -t   timeout      Set a time limit for requests in ms/s (default: %s)
+          -i   interval     Set a wait time between sending each request in ms/s (default: %s)
           -m   method       HTTP methods: GET/POST/HEAD (default: %s)
           -d   data         Sending the given data (text/json) (default: "%s")
           -u   user agent   Set user agent
@@ -448,6 +448,7 @@ func help(cfg cli.Config) {
 		  `,
 		cfg.Hping.Count,
 		cfg.Hping.Timeout,
+		cfg.Hping.Interval,
 		cfg.Hping.Method,
 		cfg.Hping.Data)
 }


### PR DESCRIPTION
Hello!

This PR makes hping interval a configurable setting (and shows the default in hping help). Also cleaned up the syntax a little in hping help.

PS. This build might fail in travis because http/ping references github.com/mehrdadrad/mylg/cli and this PR has some changes in cli/config.go.